### PR TITLE
Ignore chronopin/ (separate app repo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ application.linux64
 application.windows32
 application.windows64
 application.macosx
+
+# Separate project — own GitHub repo
+chronopin/


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`chronopin/` is a separate Expo app and should not live inside this Processing project. This PR ignores that folder so it does not get committed here by accident.

The ChronoPin app will be published under its own GitHub repository once created.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5d95-a60d-76bf-9a31-96480fab1ec7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5d95-a60d-76bf-9a31-96480fab1ec7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

